### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/renderingtheworld.py
+++ b/examples/renderingtheworld.py
@@ -40,7 +40,7 @@ def main(argv):
         style='_null',
         format='image/png',
         tile_matrix_set='EPSG:900913',
-        tile_matrix=lambda z: 'EPSG:900913:%d' % (z,))
+        tile_matrix=lambda z: 'EPSG:900913:{0:d}'.format(z))
     tilestream = generate_tilestore.get(tilestream)
     tilestream = imap(Logger(logger, logging.INFO, 'got %(tilecoord)s, error=%(error)s'), tilestream)
     # Put the tile back into the RenderingTheWorld tile store.  This check whether the tile should be subdivided, and, if so, adds the tile's children to the list of tiles to be generated.

--- a/tilecloud/__init__.py
+++ b/tilecloud/__init__.py
@@ -92,9 +92,9 @@ class Bounds(object):
 
     def __repr__(self):  # pragma: no cover
         if self.start is None:
-            return '%s(None)' % (self.__class__.__name__,)
+            return '{0!s}(None)'.format(self.__class__.__name__)
         else:
-            return '%s(%r, %r)' % (self.__class__.__name__,
+            return '{0!s}({1!r}, {2!r})'.format(self.__class__.__name__,
                                    self.start, self.stop)
 
     def add(self, value):
@@ -241,8 +241,7 @@ class BoundingPyramid(object):
             r'(?:(?P<plusx>\+)?(?P<x2>\d+)|(?P<starx>\*))/' +
             r'(?:(?P<plusy>\+)?(?P<y2>\d+)|(?P<stary>\*))\Z', s)
         if not match:
-            raise ValueError('invalid literal for %s.from_string(): %r' %
-                             (cls.__name__, s))
+            raise ValueError('invalid literal for {0!s}.from_string(): {1!r}'.format(cls.__name__, s))
         z1 = int(match.group('z1'))
         x1 = int(match.group('x1'))
         if match.group('starx'):
@@ -333,8 +332,8 @@ class Tile(object):
 
         """
         keys = sorted(self.__dict__.keys())
-        attrs = ''.join(' %s=%r' % (key, self.__dict__[key]) for key in keys)
-        return '<Tile%s>' % (attrs,)
+        attrs = ''.join(' {0!s}={1!r}'.format(key, self.__dict__[key]) for key in keys)
+        return '<Tile{0!s}>'.format(attrs)
 
 
 class TileCoord(object):
@@ -406,10 +405,10 @@ class TileCoord(object):
 
         """
         if self.n == 1:
-            return '%s(%r, %r, %r)' % (self.__class__.__name__,
+            return '{0!s}({1!r}, {2!r}, {3!r})'.format(self.__class__.__name__,
                                        self.z, self.x, self.y)
         else:
-            return '%s(%r, %r, %r, %r)' % (self.__class__.__name__,
+            return '{0!s}({1!r}, {2!r}, {3!r}, {4!r})'.format(self.__class__.__name__,
                                            self.z, self.x, self.y, self.n)
 
     def __str__(self):
@@ -420,9 +419,9 @@ class TileCoord(object):
 
         """
         if self.n == 1:
-            return '%d/%d/%d' % (self.z, self.x, self.y)
+            return '{0:d}/{1:d}/{2:d}'.format(self.z, self.x, self.y)
         else:
-            return '%d/%d/%d:+%d/+%d' % (self.z, self.x, self.y, self.n, self.n)
+            return '{0:d}/{1:d}/{2:d}:+{3:d}/+{4:d}'.format(self.z, self.x, self.y, self.n, self.n)
 
     def metatilecoord(self, n=8):
         return TileCoord(self.z, n * (self.x // n), n * (self.y // n), n)
@@ -434,7 +433,7 @@ class TileCoord(object):
     def from_string(cls, s):
         m = re.match(r'(\d+)/(\d+)/(\d+)(?::\+(\d+)/\+\4)?\Z', s)
         if not m:
-            raise ValueError('invalid literal for %s.from_string: %r' % (cls.__name__, s))
+            raise ValueError('invalid literal for {0!s}.from_string: {1!r}'.format(cls.__name__, s))
         x, y, z, n = m.groups()
         return cls(int(x), int(y), int(z), int(n) if n else 1)
 

--- a/tilecloud/filter/benchmark.py
+++ b/tilecloud/filter/benchmark.py
@@ -24,7 +24,7 @@ class Statistics(object):
         result = []
         if self.n:
             result.append('/'.join(self.format % value for value in (self.minimum, self.mean, self.maximum)))
-        result.append('(n=%d)' % (self.n,))
+        result.append('(n={0:d})'.format(self.n))
         return ' '.join(result)
 
     @property
@@ -78,7 +78,7 @@ class Benchmark(object):
                     if statistics:
                         statistics.add(delta_t)
                     if self.statsd:
-                        self.statsd.send('%s:%.3f|ms' % (key, delta_t))
+                        self.statsd.send('{0!s}:{1:.3f}|ms'.format(key, delta_t))
                 else:
                     setattr(tile, self.attr, [time.time()])
             return tile

--- a/tilecloud/layout/osm.py
+++ b/tilecloud/layout/osm.py
@@ -14,7 +14,7 @@ class OSMTileLayout(RETileLayout):
         RETileLayout.__init__(self, self.PATTERN, self.RE)
 
     def filename(self, tilecoord):
-        return '%d/%d/%d' % (tilecoord.z, tilecoord.x, tilecoord.y)
+        return '{0:d}/{1:d}/{2:d}'.format(tilecoord.z, tilecoord.x, tilecoord.y)
 
     def _tilecoord(self, match):
         return TileCoord(*map(int, match.groups()))

--- a/tilecloud/layout/re_.py
+++ b/tilecloud/layout/re_.py
@@ -10,8 +10,7 @@ class RETileLayout(TileLayout):
     def tilecoord(self, filename):
         match = self.filename_re.match(filename)
         if not match:
-            raise ValueError('invalid literal for %s.tilecoord(): %r' %
-                             (self.__class__.__name__, filename))
+            raise ValueError('invalid literal for {0!s}.tilecoord(): {1!r}'.format(self.__class__.__name__, filename))
         return self._tilecoord(match)
 
     def _tilecoord(self, match):  # pragma: no cover

--- a/tilecloud/layout/template.py
+++ b/tilecloud/layout/template.py
@@ -17,7 +17,7 @@ class TemplateTileLayout(RETileLayout):
             patterns.append(prematch_pattern)
             patterns.append(r'\d+')
             filename_patterns.append(prematch_pattern)
-            filename_patterns.append(r'(?P<%s>\d+)' % match.group(1))
+            filename_patterns.append(r'(?P<{0!s}>\d+)'.format(match.group(1)))
             index = match.end()
         postmatch_pattern = re.escape(self.template[index:])
         patterns.append(postmatch_pattern)

--- a/tilecloud/layout/tilecache.py
+++ b/tilecloud/layout/tilecache.py
@@ -14,9 +14,9 @@ class TileCacheDiskLayout(RETileLayout):
         RETileLayout.__init__(self, self.PATTERN, self.RE)
 
     def filename(self, tilecoord):
-        zs = '%02d' % (tilecoord.z,)
-        xs = '%09d' % (tilecoord.x,)
-        ys = '%09d' % (tilecoord.y,)
+        zs = '{0:02d}'.format(tilecoord.z)
+        xs = '{0:09d}'.format(tilecoord.x)
+        ys = '{0:09d}'.format(tilecoord.y)
         return '/'.join((zs, xs[0:3], xs[3:6], xs[6:9], ys[0:3], ys[3:6], ys[6:9]))
 
     def _tilecoord(self, _match):

--- a/tilecloud/layout/wms.py
+++ b/tilecloud/layout/wms.py
@@ -26,7 +26,7 @@ class WMSTileLayout(TileLayout):
         bbox = self.tilegrid.extent(tilecoord, self.border)
         size = tilecoord.n * self.tilegrid.tile_size + 2 * self.border
         params = self.params.copy()
-        params['BBOX'] = '%f,%f,%f,%f' % bbox
+        params['BBOX'] = '{0:f},{1:f},{2:f},{3:f}'.format(*bbox)
         params['WIDTH'] = size
         params['HEIGHT'] = size
         return self.url + '?' + urlencode(params)

--- a/tilecloud/layout/wrapped.py
+++ b/tilecloud/layout/wrapped.py
@@ -26,6 +26,5 @@ class WrappedTileLayout(TileLayout):
     def tilecoord(self, filename):
         match = self.filename_re.match(filename)
         if not match:
-            raise ValueError('invalid literal for %s.tilecoord(): %r' %
-                             (self.__class__.__name__, filename))
+            raise ValueError('invalid literal for {0!s}.tilecoord(): {1!r}'.format(self.__class__.__name__, filename))
         return self.tilelayout.tilecoord(match.group(1))

--- a/tilecloud/lib/memcached.py
+++ b/tilecloud/lib/memcached.py
@@ -15,7 +15,7 @@ class MemcachedClient(object):
         self.buffer = ''
 
     def delete(self, key):
-        self.writeline('delete %s' % (key,))
+        self.writeline('delete {0!s}'.format(key))
         line = self.readline()
         if line == 'DELETED':
             return True
@@ -25,7 +25,7 @@ class MemcachedClient(object):
             raise MemcachedError(line)
 
     def get(self, key):
-        self.writeline('get %s' % (key,))
+        self.writeline('get {0!s}'.format(key))
         line = self.readline()
         if line == 'END':
             return None, None, None
@@ -42,7 +42,7 @@ class MemcachedClient(object):
         return flags, value, cas
 
     def set(self, key, flags, exptime, value):
-        self.writeline('set %s %d %d %d' % (key, flags, exptime, len(value)))
+        self.writeline('set {0!s} {1:d} {2:d} {3:d}'.format(key, flags, exptime, len(value)))
         self.writeline(value)
         line = self.readline()
         if line != 'STORED':

--- a/tilecloud/lib/wmts.py
+++ b/tilecloud/lib/wmts.py
@@ -41,7 +41,7 @@ def matrix_sets(tile_matrix_set):
             "resolution": resolution,
             # 0.000028 corresponds to 0.28 mm per pixel
             "scale": resolution * METERS_PER_UNIT[units] / 0.00028,
-            "topleft": "%f %f" % (tile_matrix_set['bbox'][0], maxy)
+            "topleft": "{0:f} {1:f}".format(tile_matrix_set['bbox'][0], maxy)
         })
     sets[tile_matrix_set['name']] = matrix_set
 

--- a/tilecloud/store/tilejson.py
+++ b/tilecloud/store/tilejson.py
@@ -43,7 +43,7 @@ class TileJSONTileStore(URLTileStore):
             content_types = set(mimetypes.types_map.get(ext) for ext in exts)
             assert len(content_types) == 1
             kwargs['content_type'] = content_types.pop()
-        templates = [re.sub(r'\{([xyz])\}', lambda m: '%%(%s)d' % m.group(1), url2)
+        templates = [re.sub(r'\{([xyz])\}', lambda m: '%({0!s})d'.format(m.group(1)), url2)
                      for url2 in urls]
         tilelayouts = map(TemplateTileLayout, templates)
         URLTileStore.__init__(self, tilelayouts, **kwargs)

--- a/tilecloud/store/url.py
+++ b/tilecloud/store/url.py
@@ -23,7 +23,7 @@ class URLTileStore(TileStore):
                                       len(self.tilelayouts)]
         url = tilelayout.filename(tile.tilecoord)
 
-        logger.info('GET %s' % (url,))
+        logger.info('GET {0!s}'.format(url))
         try:
             response = self.session.get(url)
             if response.status_code == 404:

--- a/tiles/mapquest_com.py
+++ b/tiles/mapquest_com.py
@@ -6,6 +6,6 @@ from tilecloud.store.url import URLTileStore
 
 
 tilestore = URLTileStore(
-    (TemplateTileLayout('http://otile%d.mqcdn.com/tiles/1.0.0/osm/%%(z)d/%%(x)d/%%(y)d.png' % i) for i in xrange(1, 5)),
+    (TemplateTileLayout('http://otile{0:d}.mqcdn.com/tiles/1.0.0/osm/%(z)d/%(x)d/%(y)d.png'.format(i)) for i in xrange(1, 5)),
     attribution='Data, imagery and map information provided by MapQuest, <a href="http://www.openstreetmap.org/">Open Street Map</a> and contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>.',
     content_type='image/png')

--- a/tiles/medford_buildings.py
+++ b/tiles/medford_buildings.py
@@ -7,4 +7,4 @@ tilestore = WMTSTileStore(
     style='_null',
     format='image/png',
     tile_matrix_set='EPSG:900913',
-    tile_matrix=lambda z: 'EPSG:900913:%d' % (z,))
+    tile_matrix=lambda z: 'EPSG:900913:{0:d}'.format(z))

--- a/tiles/openstreetmap_org.py
+++ b/tiles/openstreetmap_org.py
@@ -3,5 +3,5 @@ from tilecloud.store.url import URLTileStore
 
 
 tilestore = URLTileStore(
-    (TemplateTileLayout('http://%s.tile.openstreetmap.org/%%(z)d/%%(x)d/%%(y)d.png' % server) for server in 'abc'),
+    (TemplateTileLayout('http://{0!s}.tile.openstreetmap.org/%(z)d/%(x)d/%(y)d.png'.format(server)) for server in 'abc'),
     attribution='&copy; OpenStreetMap contributors, CC-BY-SA', content_type='image/png')

--- a/tiles/stamen_com/terrain.py
+++ b/tiles/stamen_com/terrain.py
@@ -3,6 +3,6 @@ from tilecloud.store.url import URLTileStore
 
 
 tilestore = URLTileStore(
-    (TemplateTileLayout('http://%s.tile.stamen.com/terrain/%%(z)d/%%(x)d/%%(y)d.jpg' % server) for server in 'abcd'),
+    (TemplateTileLayout('http://{0!s}.tile.stamen.com/terrain/%(z)d/%(x)d/%(y)d.jpg'.format(server)) for server in 'abcd'),
     attribution='Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.',
     content_type='image/jpg')

--- a/tiles/stamen_com/toner.py
+++ b/tiles/stamen_com/toner.py
@@ -3,6 +3,6 @@ from tilecloud.store.url import URLTileStore
 
 
 tilestore = URLTileStore(
-    (TemplateTileLayout('http://%s.tile.stamen.com/toner/%%(z)d/%%(x)d/%%(y)d.png' % server) for server in 'abcd'),
+    (TemplateTileLayout('http://{0!s}.tile.stamen.com/toner/%(z)d/%(x)d/%(y)d.png'.format(server)) for server in 'abcd'),
     attribution='Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.',
     content_type='image/png')

--- a/tiles/stamen_com/watercolor.py
+++ b/tiles/stamen_com/watercolor.py
@@ -3,6 +3,6 @@ from tilecloud.store.url import URLTileStore
 
 
 tilestore = URLTileStore(
-    (TemplateTileLayout('http://%s.tile.stamen.com/watercolor/%%(z)d/%%(x)d/%%(y)d.jpg' % server) for server in 'abcd'),
+    (TemplateTileLayout('http://{0!s}.tile.stamen.com/watercolor/%(z)d/%(x)d/%(y)d.jpg'.format(server)) for server in 'abcd'),
     attribution='Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.',
     content_type='image/jpg')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sbrunner:tilecloud?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sbrunner:tilecloud?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)